### PR TITLE
feat: initial scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Lint install.sh
+        run: shellcheck --severity=warning install.sh
+
+  syntax:
+    name: Bash Syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check install.sh syntax
+        run: bash -n install.sh
+
+      - name: Check mirrors.txt format
+        run: |
+          # Must contain at least one non-comment domain line
+          if ! grep -qE '^[^#[:space:]]' mirrors.txt; then
+            echo "mirrors.txt contains no valid domain entries" >&2
+            exit 1
+          fi
+          # Each domain line must look like a valid hostname (letters, digits, dots, hyphens)
+          while IFS= read -r line; do
+            [[ "$line" =~ ^[[:space:]]*# ]] && continue  # comment
+            [[ -z "$line" ]] && continue                  # blank
+            if ! [[ "$line" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]+[a-zA-Z0-9]$ ]]; then
+              echo "Invalid domain in mirrors.txt: '${line}'" >&2
+              exit 1
+            fi
+          done < mirrors.txt
+          echo "mirrors.txt is valid"
+
+  dry-run:
+    name: Dry-run (Linux compat check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Patch script for Linux dry-run
+        # The script exits on non-Darwin; stub out the OS check so we can
+        # exercise argument parsing and logic on the CI runner.
+        run: |
+          sed 's/\[\[ "$(uname -s)" == "Darwin" \]\]/true/' install.sh > install-test.sh
+          chmod +x install-test.sh
+
+      - name: Run dry-run (no-fetch, no root required)
+        run: bash install-test.sh --dry-run --no-fetch 2>&1 || true
+        # We expect non-zero exit because /etc/resolver doesn't exist on Linux;
+        # the goal is to verify flag parsing and early-stage logic don't crash.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate tag format
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag '${TAG}' does not match vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+
+      - name: Verify script version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          SCRIPT_VERSION="$(grep -oP "(?<=SCRIPT_VERSION=\")[^\"]+" install.sh)"
+          if [[ "$TAG_VERSION" != "$SCRIPT_VERSION" ]]; then
+            echo "Tag version (${TAG_VERSION}) does not match SCRIPT_VERSION in install.sh (${SCRIPT_VERSION})" >&2
+            exit 1
+          fi
+
+      - name: Install ShellCheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Lint before release
+        run: shellcheck --severity=warning install.sh
+
+      - name: Validate mirrors.txt
+        run: |
+          if ! grep -qE '^[^#[:space:]]' mirrors.txt; then
+            echo "mirrors.txt contains no valid domain entries" >&2
+            exit 1
+          fi
+
+      - name: Create release archive
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          ARCHIVE="archive-resolver-${VERSION}.tar.gz"
+          tar -czf "$ARCHIVE" \
+            install.sh \
+            mirrors.txt \
+            README.md \
+            LICENSE.md
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          DATE="$(date -u '+%Y-%m-%d')"
+          MIRROR_COUNT="$(grep -cE '^[^#[:space:]]' mirrors.txt)"
+
+          cat > release_notes.md <<EOF
+          ## ${VERSION} — ${DATE}
+
+          ### What's included
+
+          - \`install.sh\` — idempotent macOS DNS override installer
+          - \`mirrors.txt\` — ${MIRROR_COUNT} archive.today mirror domains
+
+          ### Install
+
+          \`\`\`sh
+          RELEASE_URL="https://github.com/${{ github.repository }}"
+          curl -fsSL "${RELEASE_URL}/releases/download/${VERSION}/archive-resolver-${VERSION}.tar.gz" \\
+            | tar -xz
+          sudo ./install.sh
+          \`\`\`
+
+          Or run directly from \`main\` (always uses latest mirror list):
+
+          \`\`\`sh
+          git clone https://github.com/${{ github.repository }}.git
+          cd archive-resolver
+          sudo ./install.sh
+          \`\`\`
+
+          ### Mirrors in this release
+
+          $(grep -E '^[^#[:space:]]' mirrors.txt | sed 's/^/- /')
+          EOF
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "archive-resolver $GITHUB_REF_NAME" \
+            --notes-file release_notes.md \
+            "$ARCHIVE" \
+            install.sh \
+            mirrors.txt

--- a/.github/workflows/update-mirrors.yml
+++ b/.github/workflows/update-mirrors.yml
@@ -73,6 +73,16 @@ jobs:
             diff <(echo "$CURRENT_SORTED") <(echo "$NEW_SORTED") \
               | grep '^[<>]' | sed 's/^< /  removed: /; s/^> /  added:   /' || true
 
+            # Save the diff before overwriting mirrors.txt — the Create pull request
+            # step runs in a separate shell and mirrors.txt will already be updated by then.
+            DIFF_SUMMARY="$(diff \
+              <(echo "$CURRENT_SORTED") \
+              <(echo "$NEW_SORTED") \
+              | grep '^[<>]' | sed 's/^< /- removed: /; s/^> /+ added: /' || echo 'See diff')"
+            echo "diff_summary<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$DIFF_SUMMARY" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+
             # Write updated mirrors.txt
             {
               echo "# archive-resolver mirror list"
@@ -100,11 +110,7 @@ jobs:
           git commit -m "chore: update mirror list from Wikipedia (${DATE})"
           git push origin "$BRANCH"
 
-          DIFF_SUMMARY="$(diff \
-            <(grep -E '^[^#[:space:]]' mirrors.txt | sort) \
-            <(cat /tmp/ordered_domains.txt | sort) \
-            | grep '^[<>]' | sed 's/^< /- removed: /; s/^> /+ added: /' || echo 'See diff')"
-
+          DIFF_SUMMARY="${{ steps.check.outputs.diff_summary }}"
           WIKI_URL="https://en.wikipedia.org/wiki/Archive.today"
           gh pr create \
             --title "chore: update mirror list from Wikipedia (${DATE})" \

--- a/.github/workflows/update-mirrors.yml
+++ b/.github/workflows/update-mirrors.yml
@@ -1,0 +1,136 @@
+name: Update mirror list
+
+on:
+  schedule:
+    # First Monday of every month at 09:07 UTC
+    - cron: "7 9 1-7 * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (show changes without creating a PR)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-mirrors:
+    name: Check Wikipedia for mirror changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch and parse mirror list from Wikipedia
+        id: check
+        run: |
+          WIKIPEDIA_API="https://en.wikipedia.org/w/api.php?action=parse&page=Archive.today&prop=text&format=json"
+
+          echo "Fetching Wikipedia article..."
+          curl --silent --fail --max-time 30 --location "$WIKIPEDIA_API" -o /tmp/wiki.json
+
+          # Extract <li>archive.TLD</li> entries from the infobox HTML.
+          # Writing to a temp file avoids any shell-quoting issues with the JSON.
+          python3 - /tmp/wiki.json <<'PYEOF' > /tmp/new_domains.txt
+          import sys, json, re
+
+          with open(sys.argv[1]) as f:
+              html = json.load(f)['parse']['text']['*']
+
+          found = re.findall(r'<li>(archive\.[a-z]{2,6})</li>', html)
+          seen = set()
+          for d in found:
+              if d not in seen:
+                  seen.add(d)
+                  print(d)
+          PYEOF
+
+          if [[ ! -s /tmp/new_domains.txt ]]; then
+            echo "ERROR: No domains extracted from Wikipedia article" >&2
+            exit 1
+          fi
+
+          # Ensure archive.today is first; preserve Wikipedia article ordering for the rest.
+          {
+            echo "archive.today"
+            grep -v '^archive\.today$' /tmp/new_domains.txt
+          } > /tmp/ordered_domains.txt
+
+          echo "Domains found on Wikipedia:"
+          cat /tmp/ordered_domains.txt
+
+          # Compare sorted sets (order differences don't constitute an update).
+          CURRENT_SORTED="$(grep -E '^[^#[:space:]]' mirrors.txt | sed 's/[[:space:]]*//' | sort)"
+          NEW_SORTED="$(sort /tmp/ordered_domains.txt)"
+
+          if [[ "$CURRENT_SORTED" == "$NEW_SORTED" ]]; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+            echo "No changes detected — mirrors.txt is up to date."
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+            echo "Changes detected:"
+            diff <(echo "$CURRENT_SORTED") <(echo "$NEW_SORTED") \
+              | grep '^[<>]' | sed 's/^< /  removed: /; s/^> /  added:   /' || true
+
+            # Write updated mirrors.txt
+            {
+              echo "# archive-resolver mirror list"
+              echo "# Format: one domain per line. Lines starting with # are comments."
+              echo "# The first non-comment line is the primary domain (others become symlinks)."
+              echo "#"
+              echo "# Source: https://en.wikipedia.org/wiki/Archive.today"
+              printf "# Updated: %s\n" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+              cat /tmp/ordered_domains.txt
+            } > mirrors.txt
+          fi
+
+      - name: Create pull request
+        if: steps.check.outputs.up_to_date == 'false' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DATE="$(date -u '+%Y-%m-%d')"
+          BRANCH="chore/update-mirrors-${DATE}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add mirrors.txt
+          git commit -m "chore: update mirror list from Wikipedia (${DATE})"
+          git push origin "$BRANCH"
+
+          DIFF_SUMMARY="$(diff \
+            <(grep -E '^[^#[:space:]]' mirrors.txt | sort) \
+            <(cat /tmp/ordered_domains.txt | sort) \
+            | grep '^[<>]' | sed 's/^< /- removed: /; s/^> /+ added: /' || echo 'See diff')"
+
+          WIKI_URL="https://en.wikipedia.org/wiki/Archive.today"
+          gh pr create \
+            --title "chore: update mirror list from Wikipedia (${DATE})" \
+            --body "Automated update of \`mirrors.txt\` based on the
+          current [Archive.today Wikipedia article](${WIKI_URL}).
+
+          **Changes:**
+          \`\`\`
+          ${DIFF_SUMMARY}
+          \`\`\`
+
+          **Review checklist:**
+          - [ ] Verify removed domains are genuinely discontinued mirrors
+          - [ ] Verify added domains are genuine archive.today mirrors
+          - [ ] Confirm \`archive.today\` remains the first (primary) entry" \
+            --label "automated" \
+            --head "$BRANCH" \
+            --base main
+
+      - name: Dry run summary
+        if: inputs.dry_run == 'true'
+        run: |
+          if [[ "${{ steps.check.outputs.up_to_date }}" == "true" ]]; then
+            echo "Dry run: mirrors.txt is already up to date."
+          else
+            echo "Dry run: changes detected. A PR would be created if dry_run=false."
+            echo "Updated mirror list:"
+            cat /tmp/ordered_domains.txt
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .claude/
+*.tar.gz
+install-test.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,133 @@
+# archive-resolver
+
+Fixes DNS-based access blocks to [archive.today](https://archive.today) and its mirrors on macOS.
+
+## The problem
+
+archive.today intentionally denies requests from users whose DNS resolves through certain providers — most notably **Cloudflare 1.1.1.1**. The dispute is over [EDNS Client Subnet](https://en.wikipedia.org/wiki/EDNS_Client_Subnet): archive.today's operator uses it for load balancing; Cloudflare refuses to send it on privacy grounds. The result is that anyone using Cloudflare DNS gets connection errors on every archive.today domain.
+
+## The fix
+
+macOS supports per-domain DNS resolver overrides via files in `/etc/resolver/`. This script creates one file per mirror domain, routing those domains through a public nameserver (Google DNS 8.8.8.8 by default) while leaving all other DNS traffic alone.
+
+## Mirror domains
+
+The mirror list is in [`mirrors.txt`](./mirrors.txt), updated monthly by a GitHub Actions workflow that reads the [Archive.today Wikipedia article](https://en.wikipedia.org/wiki/Archive.today). Current mirrors:
+
+| Domain | Role |
+|---|---|
+| archive.today | Primary |
+| archive.fo | Mirror |
+| archive.is | Mirror (deprecated for new links, still active) |
+| archive.li | Mirror |
+| archive.md | Mirror |
+| archive.ph | Mirror |
+| archive.vn | Mirror |
+
+## Requirements
+
+- macOS 10.6+ (any version with `/etc/resolver` support)
+- `sudo` / root access (for install/uninstall only)
+- `curl` and `python3` (both ship with macOS)
+
+## Quick install
+
+```sh
+git clone https://github.com/smartwatermelon/archive-resolver.git
+cd archive-resolver
+sudo ./install.sh
+```
+
+## Usage
+
+```
+./install.sh --update-mirrors        Update mirrors.txt from Wikipedia (no root needed)
+sudo ./install.sh                    Install / update resolver files
+sudo ./install.sh --uninstall        Remove all managed resolver files
+
+Options:
+  -m, --update-mirrors   Fetch current mirror list from Wikipedia and update mirrors.txt
+  -y, --yes              Non-interactive: skip confirmation prompts
+  -n, --nameserver IP    Nameserver for archive domains (default: 8.8.8.8)
+  -f, --no-fetch         Use local mirrors.txt; skip fetching from GitHub
+  -d, --dry-run          Show planned changes without applying them
+  -u, --uninstall        Remove all resolver files managed by archive-resolver
+  -h, --help             Show this message
+```
+
+### Examples
+
+```sh
+# Standard install / update (fetches latest mirrors.txt from GitHub)
+sudo ./install.sh
+
+# Preview what would change
+sudo ./install.sh --dry-run
+
+# Update mirrors.txt from Wikipedia, then install
+./install.sh --update-mirrors && sudo ./install.sh --no-fetch
+
+# Preview mirror list changes without writing anything
+./install.sh --update-mirrors --dry-run
+
+# Use alternate Google DNS server
+sudo ./install.sh --nameserver 8.8.4.4
+
+# Offline install (uses bundled mirrors.txt)
+sudo ./install.sh --no-fetch
+
+# Remove everything this script created
+sudo ./install.sh --uninstall
+```
+
+## How it works
+
+1. Reads `mirrors.txt` from this repository (or the local copy with `--no-fetch`).
+2. Writes `/etc/resolver/archive.today` with `nameserver 8.8.8.8`.
+3. Creates symlinks for every other mirror domain pointing at that file. Changing the nameserver only requires updating one place.
+4. Removes any `/etc/resolver` entries from a previous run that are no longer in the mirror list, using a manifest at `/etc/resolver/.archive-resolver`.
+5. Runs `dscacheutil -flushcache` and reloads `mDNSResponder`.
+
+Re-running produces the same result. New mirrors are added, removed mirrors are cleaned up.
+
+## Keeping the mirror list current
+
+A workflow runs on the first Monday of every month. If the Wikipedia article's mirror list has changed, it opens a pull request with the updated `mirrors.txt`.
+
+To pull an update locally without waiting for CI:
+
+```sh
+./install.sh --update-mirrors
+```
+
+This fetches the Wikipedia article and rewrites `mirrors.txt` if the mirror set has changed. Then run `sudo ./install.sh --no-fetch` to apply it.
+
+## Updating
+
+```sh
+sudo ./install.sh
+```
+
+Fetches the latest `mirrors.txt` from this repository and updates `/etc/resolver` to match. No script update needed.
+
+## Uninstalling
+
+```sh
+sudo ./install.sh --uninstall
+```
+
+Removes all resolver files this script created and flushes the DNS cache. System-wide DNS settings are not affected.
+
+## Verifying it works
+
+```sh
+# List managed resolver files
+ls -la /etc/resolver/archive.*
+
+# Check that archive.today resolves
+dscacheutil -q host -a name archive.today
+```
+
+## License
+
+MIT — see [LICENSE.md](./LICENSE.md).

--- a/install.sh
+++ b/install.sh
@@ -449,14 +449,31 @@ apply_install() {
 }
 
 apply_removals() {
-  local -a manifest=("$@")
-  local changes=0
+  # Arguments: desired_domain... -- manifest_domain...
+  # The "--" separator distinguishes the two arrays.
+  local -a desired=()
+  local -a manifest=()
+  local in_manifest=false
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == "--" ]]; then
+      in_manifest=true
+      continue
+    fi
+    if [[ $in_manifest == false ]]; then
+      desired+=("$arg")
+    else
+      manifest+=("$arg")
+    fi
+  done
 
+  local changes=0
   local domain
   for domain in "${manifest[@]}"; do
+    [[ -z "$domain" ]] && continue
     local keep=false
     local d
-    for d in "${DESIRED_DOMAINS[@]}"; do
+    for d in "${desired[@]}"; do
       [[ "$d" == "$domain" ]] && keep=true && break
     done
 
@@ -554,7 +571,6 @@ main() {
   check_resolver_dir
 
   mapfile -t DESIRED_DOMAINS < <(get_desired_mirrors)
-  export DESIRED_DOMAINS
 
   if [[ ${#DESIRED_DOMAINS[@]} -eq 0 ]]; then
     fatal "Mirror list is empty. Cannot continue."
@@ -570,7 +586,7 @@ main() {
 
   local install_changes removal_changes total_changes
   install_changes="$(apply_install "${DESIRED_DOMAINS[@]}")"
-  removal_changes="$(apply_removals "${MANIFEST_DOMAINS[@]:-}")"
+  removal_changes="$(apply_removals "${DESIRED_DOMAINS[@]}" -- "${MANIFEST_DOMAINS[@]:-}")"
   total_changes=$((install_changes + removal_changes))
 
   if [[ $DRY_RUN == false ]]; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,595 @@
+#!/usr/bin/env bash
+# archive-resolver: Configure macOS DNS overrides for archive.today and its mirrors.
+#
+# archive.today (and mirrors) deny access to users on certain DNS providers (notably
+# Cloudflare 1.1.1.1). This script adds per-domain resolver entries under
+# /etc/resolver so macOS routes only those domains through a trusted nameserver.
+#
+# Usage:  ./install.sh --update-mirrors    # Update mirrors.txt from Wikipedia (no root)
+#         sudo ./install.sh                # Install / update resolver files
+#
+# The script is idempotent: re-running it adds missing entries, updates changed
+# entries, and removes entries for domains no longer in the mirrors list.
+#
+# Requires: macOS, curl (for network operations), python3 (bundled on macOS)
+# Root is required only for install/uninstall, not for --update-mirrors.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+readonly SCRIPT_NAME="archive-resolver"
+readonly SCRIPT_VERSION="1.0.0"
+readonly RESOLVER_DIR="/etc/resolver"
+readonly MANIFEST_FILE="${RESOLVER_DIR}/.${SCRIPT_NAME}"
+readonly MANAGED_MARKER="managed-by: ${SCRIPT_NAME}"
+readonly WIKIPEDIA_API="https://en.wikipedia.org/w/api.php?action=parse&page=Archive.today&prop=text&format=json"
+readonly REPO_URL="https://github.com/smartwatermelon/archive-resolver"
+
+# Remote source for the mirrors list (used as install-time fallback).
+readonly MIRRORS_URL="${REPO_URL}/raw/main/mirrors.txt"
+
+# Path to mirrors.txt alongside this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly LOCAL_MIRRORS_FILE="${SCRIPT_DIR}/mirrors.txt"
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via flags)
+# ---------------------------------------------------------------------------
+NAMESERVER="8.8.8.8"
+FETCH_MIRRORS=true
+DRY_RUN=false
+UNINSTALL=false
+UPDATE_MIRRORS=false
+YES=false
+
+# ---------------------------------------------------------------------------
+# Colours (suppressed when stdout is not a terminal)
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  CYAN='\033[0;36m'
+  BOLD='\033[1m'
+  RESET='\033[0m'
+else
+  RED=''
+  GREEN=''
+  YELLOW=''
+  CYAN=''
+  BOLD=''
+  RESET=''
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info() { echo -e "${CYAN}[info]${RESET}  $*" >&2; }
+success() { echo -e "${GREEN}[ok]${RESET}    $*" >&2; }
+warn() { echo -e "${YELLOW}[warn]${RESET}  $*" >&2; }
+error() { echo -e "${RED}[error]${RESET} $*" >&2; }
+fatal() {
+  error "$*"
+  exit 1
+}
+
+header() {
+  echo -e "\n${BOLD}${SCRIPT_NAME} v${SCRIPT_VERSION}${RESET}" >&2
+  echo "─────────────────────────────────────────" >&2
+}
+
+usage() {
+  cat <<EOF
+Usage:
+  ./install.sh --update-mirrors        Update mirrors.txt from Wikipedia (no root needed)
+  sudo ./install.sh                    Install / update resolver files
+  sudo ./install.sh --uninstall        Remove all managed resolver files
+
+Options:
+  -m, --update-mirrors   Fetch current mirror list from Wikipedia and update mirrors.txt
+  -y, --yes              Non-interactive: skip confirmation prompts (use with --update-mirrors)
+  -n, --nameserver IP    Nameserver for archive domains (default: 8.8.8.8)
+  -f, --no-fetch         Use local mirrors.txt; skip fetching from GitHub
+  -d, --dry-run          Show planned changes without applying them
+  -u, --uninstall        Remove all resolver files managed by ${SCRIPT_NAME}
+  -h, --help             Show this message
+
+Examples:
+  ./install.sh --update-mirrors        # Refresh mirrors.txt from Wikipedia
+  ./install.sh --update-mirrors --dry-run   # Preview mirror list changes only
+  sudo ./install.sh                    # Install (fetches mirrors.txt from GitHub)
+  sudo ./install.sh --no-fetch         # Install using bundled mirrors.txt (offline)
+  sudo ./install.sh --nameserver 8.8.4.4   # Use alternate Google DNS
+  sudo ./install.sh --uninstall        # Remove everything
+  sudo ./install.sh --dry-run          # Preview resolver changes
+
+Workflow for updating the mirror list and re-installing in one shot:
+  ./install.sh --update-mirrors && sudo ./install.sh --no-fetch
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -m | --update-mirrors)
+        UPDATE_MIRRORS=true
+        shift
+        ;;
+      -y | --yes)
+        YES=true
+        shift
+        ;;
+      -n | --nameserver)
+        [[ -z "${2:-}" ]] && fatal "--nameserver requires an IP address argument"
+        NAMESERVER="$2"
+        shift 2
+        ;;
+      -f | --no-fetch)
+        FETCH_MIRRORS=false
+        shift
+        ;;
+      -d | --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      -u | --uninstall)
+        UNINSTALL=true
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *) fatal "Unknown option: $1 (run with --help for usage)" ;;
+    esac
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+check_os() {
+  [[ "$(uname -s)" == "Darwin" ]] || fatal "This script only supports macOS."
+}
+
+check_root() {
+  if [[ $DRY_RUN == false && $EUID -ne 0 ]]; then
+    fatal "Root privileges required. Re-run with: sudo $0 ${*:-}"
+  fi
+}
+
+check_resolver_dir() {
+  if [[ ! -d "$RESOLVER_DIR" ]]; then
+    if [[ $DRY_RUN == true ]]; then
+      warn "[dry-run] Would create directory: ${RESOLVER_DIR}"
+    else
+      info "Creating ${RESOLVER_DIR}"
+      mkdir -p "$RESOLVER_DIR"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fetch mirror list from Wikipedia
+# ---------------------------------------------------------------------------
+# Queries the Wikipedia API for the Archive.today article and extracts the
+# mirror domains from the infobox, where they appear as bare <li> elements:
+#   <li>archive.today</li>
+#   <li>archive.fo</li>  ... etc.
+#
+# This is intentionally precise to avoid false positives (e.g. archive.org,
+# web.archive.org) that also appear in the article body as references.
+# Returns domains one per line, archive.today first.
+fetch_mirrors_from_wikipedia() {
+  local url="$WIKIPEDIA_API"
+  local json domains
+
+  info "Fetching Wikipedia article: Archive.today"
+  if ! json="$(curl --silent --fail --max-time 20 --location "$url" 2>/dev/null)"; then
+    warn "Could not reach Wikipedia API"
+    return 1
+  fi
+
+  # python3 is bundled on macOS and required for JSON parsing.
+  if ! command -v python3 &>/dev/null; then
+    warn "python3 not found — required to parse Wikipedia API response"
+    return 1
+  fi
+
+  # Extract domains from <li>archive.*</li> elements in the infobox.
+  # These are the only place in the article where the mirrors appear as
+  # bare domain names without surrounding text.
+  domains="$(printf '%s' "$json" | python3 -c "
+import sys, json, re
+try:
+    html = json.load(sys.stdin)['parse']['text']['*']
+except Exception:
+    sys.exit(1)
+# Match <li>archive.TLD</li> where TLD is 2-6 lowercase letters.
+# This targets the infobox domain list and nothing else.
+found = re.findall(r'<li>(archive\.[a-z]{2,6})</li>', html)
+# Deduplicate while preserving order.
+seen = set()
+for d in found:
+    if d not in seen:
+        seen.add(d)
+        print(d)
+")" || {
+    warn "Failed to extract domains from Wikipedia article"
+    return 1
+  }
+
+  if [[ -z "$domains" ]]; then
+    warn "No mirror domains found in Wikipedia article infobox"
+    return 1
+  fi
+
+  # Ensure archive.today is first (it is always the primary domain).
+  # If it was not already first, move it there.
+  local rest
+  rest="$(printf '%s\n' "$domains" | grep -v '^archive\.today$')"
+  printf 'archive.today\n'
+  [[ -n "$rest" ]] && printf '%s\n' "$rest"
+}
+
+# ---------------------------------------------------------------------------
+# Update mirrors.txt from Wikipedia
+# ---------------------------------------------------------------------------
+do_update_mirrors() {
+  local raw
+  local -a new_domains current_domains
+
+  if ! raw="$(fetch_mirrors_from_wikipedia)"; then
+    fatal "Could not fetch mirror list from Wikipedia."
+  fi
+
+  mapfile -t new_domains < <(printf '%s\n' "$raw")
+
+  if [[ ${#new_domains[@]} -eq 0 || -z "${new_domains[0]:-}" ]]; then
+    fatal "Wikipedia returned an empty domain list."
+  fi
+
+  # Read current list for comparison
+  if [[ -f "$LOCAL_MIRRORS_FILE" ]]; then
+    mapfile -t current_domains < <(parse_mirrors_file "$LOCAL_MIRRORS_FILE")
+  else
+    current_domains=()
+  fi
+
+  # Compare as sorted sets: ordering differences do not constitute an update.
+  # The primary domain (archive.today) must always be first, but the rest
+  # can appear in any order without requiring a rewrite.
+  local new_sorted current_sorted
+  new_sorted="$(printf '%s\n' "${new_domains[@]}" | sort)"
+  current_sorted="$(printf '%s\n' "${current_domains[@]:-}" | sort)"
+
+  if [[ "$new_sorted" == "$current_sorted" ]]; then
+    success "mirrors.txt is already up to date (${#new_domains[@]} domains)."
+    return 0
+  fi
+
+  # Show set-level additions and removals only
+  info "Changes detected:"
+  diff <(printf '%s\n' "${current_domains[@]:-}" | sort) \
+    <(printf '%s\n' "${new_domains[@]}" | sort) \
+    | grep '^[<>]' \
+    | sed 's|^< |  removed: |; s|^> |  added:   |' >&2 || true
+  echo >&2
+
+  if [[ $DRY_RUN == true ]]; then
+    info "[dry-run] Would update: ${LOCAL_MIRRORS_FILE}"
+    return 0
+  fi
+
+  # Confirm unless --yes or non-interactive
+  if [[ $YES == false && -t 0 ]]; then
+    local response
+    read -r -p "Update mirrors.txt? [y/N] " response
+    [[ "$response" =~ ^[Yy] ]] || {
+      info "Aborted."
+      return 0
+    }
+  fi
+
+  {
+    echo "# archive-resolver mirror list"
+    echo "# Format: one domain per line. Lines starting with # are comments."
+    echo "# The first non-comment line is the primary domain (others become symlinks)."
+    echo "#"
+    echo "# Source: https://en.wikipedia.org/wiki/Archive.today"
+    echo "# Updated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '%s\n' "${new_domains[@]}"
+  } >"$LOCAL_MIRRORS_FILE"
+
+  success "Updated mirrors.txt (${#new_domains[@]} domains)."
+  echo >&2
+  info "To apply the updated list, run: sudo ./install.sh --no-fetch"
+}
+
+# ---------------------------------------------------------------------------
+# Mirror list: fetch from repo → local file → exit with error
+# ---------------------------------------------------------------------------
+fetch_mirrors_from_url() {
+  local tmp
+  tmp="$(mktemp)"
+  if curl --silent --fail --max-time 10 --location "$MIRRORS_URL" -o "$tmp" 2>/dev/null; then
+    if grep -qE '^[^#[:space:]]' "$tmp"; then
+      cat "$tmp"
+      rm -f "$tmp"
+      return 0
+    fi
+  fi
+  rm -f "$tmp"
+  return 1
+}
+
+parse_mirrors_file() {
+  local file="$1"
+  grep -E '^[^#[:space:]]' "$file" | sed 's/[[:space:]].*//' || true
+}
+
+get_desired_mirrors() {
+  if [[ $FETCH_MIRRORS == true ]]; then
+    info "Fetching mirror list from ${MIRRORS_URL}"
+    local raw
+    if raw="$(fetch_mirrors_from_url)"; then
+      success "Fetched mirror list"
+      printf '%s\n' "$raw" | grep -E '^[^#[:space:]]' | sed 's/[[:space:]].*//'
+      return
+    else
+      warn "Fetch failed — falling back to local mirrors.txt"
+    fi
+  fi
+
+  if [[ -f "$LOCAL_MIRRORS_FILE" ]]; then
+    info "Using local mirror list: ${LOCAL_MIRRORS_FILE}"
+    parse_mirrors_file "$LOCAL_MIRRORS_FILE"
+    return
+  fi
+
+  fatal "No mirror list available. Run --update-mirrors first, or use --no-fetch with a local mirrors.txt."
+}
+
+# ---------------------------------------------------------------------------
+# Manifest: tracks which domains this script manages
+# ---------------------------------------------------------------------------
+read_manifest() {
+  if [[ -f "$MANIFEST_FILE" ]]; then
+    grep -E '^[^#[:space:]]' "$MANIFEST_FILE" || true
+  fi
+}
+
+write_manifest() {
+  local -a domains=("$@")
+  if [[ $DRY_RUN == true ]]; then
+    info "[dry-run] Would write manifest: ${MANIFEST_FILE}"
+    return
+  fi
+  {
+    echo "# ${MANAGED_MARKER}"
+    echo "# Updated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '%s\n' "${domains[@]}"
+  } >"$MANIFEST_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Resolver file helpers
+# ---------------------------------------------------------------------------
+resolver_content() {
+  printf '# %s\n# nameserver: %s\nnameserver %s\n' \
+    "$MANAGED_MARKER" "$1" "$1"
+}
+
+is_managed() {
+  local file="$1"
+  [[ -f "$file" ]] && grep -q "$MANAGED_MARKER" "$file"
+}
+
+is_correct_symlink() {
+  local link="$1" target="$2"
+  [[ -L "$link" ]] && [[ "$(readlink "$link")" == "$target" ]]
+}
+
+primary_is_current() {
+  local file="$1" nameserver="$2"
+  [[ -f "$file" ]] && grep -q "^nameserver ${nameserver}$" "$file"
+}
+
+# ---------------------------------------------------------------------------
+# Apply resolver changes
+# ---------------------------------------------------------------------------
+apply_install() {
+  local -a desired=("$@")
+  local primary="${desired[0]}"
+  local primary_file="${RESOLVER_DIR}/${primary}"
+  local changes=0
+
+  # Primary domain: full resolver file
+  if primary_is_current "$primary_file" "$NAMESERVER" && is_managed "$primary_file"; then
+    success "Primary resolver up to date: ${primary}"
+  else
+    if [[ $DRY_RUN == true ]]; then
+      info "[dry-run] Would write resolver: ${primary_file} → nameserver ${NAMESERVER}"
+    else
+      info "Writing resolver: ${primary_file}"
+      resolver_content "$NAMESERVER" >"$primary_file"
+      success "Wrote ${primary_file}"
+    fi
+    changes=$((changes + 1))
+  fi
+
+  # Mirror domains: symlinks → primary filename
+  local i
+  for ((i = 1; i < ${#desired[@]}; i++)); do
+    local domain="${desired[$i]}"
+    local link="${RESOLVER_DIR}/${domain}"
+
+    if is_correct_symlink "$link" "$primary"; then
+      success "Symlink up to date: ${domain} → ${primary}"
+    else
+      if [[ $DRY_RUN == true ]]; then
+        local action="create"
+        [[ -e "$link" || -L "$link" ]] && action="replace"
+        info "[dry-run] Would ${action} symlink: ${link} → ${primary}"
+      else
+        [[ -e "$link" || -L "$link" ]] && rm -f "$link"
+        ln -s "$primary" "$link"
+        success "Linked ${domain} → ${primary}"
+      fi
+      changes=$((changes + 1))
+    fi
+  done
+
+  echo "$changes"
+}
+
+apply_removals() {
+  local -a manifest=("$@")
+  local changes=0
+
+  local domain
+  for domain in "${manifest[@]}"; do
+    local keep=false
+    local d
+    for d in "${DESIRED_DOMAINS[@]}"; do
+      [[ "$d" == "$domain" ]] && keep=true && break
+    done
+
+    if [[ $keep == false ]]; then
+      local file="${RESOLVER_DIR}/${domain}"
+      if [[ $DRY_RUN == true ]]; then
+        info "[dry-run] Would remove stale entry: ${file}"
+      else
+        info "Removing stale entry: ${file}"
+        rm -f "$file"
+        success "Removed ${file}"
+      fi
+      changes=$((changes + 1))
+    fi
+  done
+
+  echo "$changes"
+}
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+do_uninstall() {
+  info "Uninstalling ${SCRIPT_NAME}..."
+  local -a managed
+  mapfile -t managed < <(read_manifest)
+
+  if [[ ${#managed[@]} -eq 0 ]]; then
+    warn "No managed resolver files found (manifest missing or empty)."
+    return
+  fi
+
+  local count=0
+  local domain
+  for domain in "${managed[@]}"; do
+    local file="${RESOLVER_DIR}/${domain}"
+    if [[ $DRY_RUN == true ]]; then
+      info "[dry-run] Would remove: ${file}"
+    elif [[ -e "$file" || -L "$file" ]]; then
+      rm -f "$file"
+      success "Removed ${file}"
+      count=$((count + 1))
+    fi
+  done
+
+  if [[ $DRY_RUN == true ]]; then
+    info "[dry-run] Would remove manifest: ${MANIFEST_FILE}"
+  else
+    rm -f "$MANIFEST_FILE"
+    success "Removed manifest"
+  fi
+
+  flush_dns
+  echo >&2
+  success "Uninstalled ${count} resolver entries."
+}
+
+# ---------------------------------------------------------------------------
+# DNS cache flush
+# ---------------------------------------------------------------------------
+flush_dns() {
+  if [[ $DRY_RUN == true ]]; then
+    info "[dry-run] Would flush DNS cache"
+    return
+  fi
+  info "Flushing DNS cache..."
+  dscacheutil -flushcache
+  killall -HUP mDNSResponder 2>/dev/null || true
+  success "DNS cache flushed"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  parse_args "$@"
+
+  header
+  check_os
+
+  # --update-mirrors does not require root; handle it before the root check.
+  if [[ $UPDATE_MIRRORS == true ]]; then
+    do_update_mirrors
+    exit 0
+  fi
+
+  check_root "$@"
+
+  if [[ $UNINSTALL == true ]]; then
+    check_resolver_dir
+    do_uninstall
+    exit 0
+  fi
+
+  check_resolver_dir
+
+  mapfile -t DESIRED_DOMAINS < <(get_desired_mirrors)
+  export DESIRED_DOMAINS
+
+  if [[ ${#DESIRED_DOMAINS[@]} -eq 0 ]]; then
+    fatal "Mirror list is empty. Cannot continue."
+  fi
+
+  local primary="${DESIRED_DOMAINS[0]}"
+  info "Primary domain : ${primary}"
+  info "Nameserver     : ${NAMESERVER}"
+  info "Mirrors total  : ${#DESIRED_DOMAINS[@]}"
+  echo >&2
+
+  mapfile -t MANIFEST_DOMAINS < <(read_manifest)
+
+  local install_changes removal_changes total_changes
+  install_changes="$(apply_install "${DESIRED_DOMAINS[@]}")"
+  removal_changes="$(apply_removals "${MANIFEST_DOMAINS[@]:-}")"
+  total_changes=$((install_changes + removal_changes))
+
+  if [[ $DRY_RUN == false ]]; then
+    write_manifest "${DESIRED_DOMAINS[@]}"
+  fi
+
+  if [[ $total_changes -gt 0 ]]; then
+    echo >&2
+    flush_dns
+  fi
+
+  echo >&2
+  if [[ $DRY_RUN == true ]]; then
+    info "Dry run complete. ${total_changes} change(s) would be applied."
+  elif [[ $total_changes -gt 0 ]]; then
+    success "Done. ${total_changes} change(s) applied."
+  else
+    success "Already up to date. No changes needed."
+  fi
+}
+
+main "$@"

--- a/mirrors.txt
+++ b/mirrors.txt
@@ -1,0 +1,13 @@
+# archive-resolver mirror list
+# Format: one domain per line. Lines starting with # are comments.
+# The first non-comment line is the primary domain (others become symlinks).
+#
+# Source: https://en.wikipedia.org/wiki/Archive.today
+# Updated: 2026-03-11T17:37:00Z
+archive.today
+archive.fo
+archive.is
+archive.li
+archive.md
+archive.ph
+archive.vn


### PR DESCRIPTION
Adds the full project scaffold: installation script, mirror list, and GitHub Actions workflows.

## What's included

**`install.sh`** — idempotent macOS DNS override installer
- Creates `/etc/resolver/archive.today` with the configured nameserver
- Symlinks all other mirror domains to the primary file
- Tracks managed entries in a manifest; removes stale entries on re-run
- `--update-mirrors` fetches the current mirror list from the Wikipedia API (no root needed)
- `--dry-run`, `--uninstall`, `--no-fetch`, `--nameserver`, `--yes`

**`mirrors.txt`** — domain list parsed from the [Archive.today Wikipedia article](https://en.wikipedia.org/wiki/Archive.today); first entry is the primary

**`.github/workflows/ci.yml`** — ShellCheck, bash syntax, and mirrors.txt format validation on every push/PR

**`.github/workflows/release.yml`** — creates a GitHub release on `vX.Y.Z` tags; verifies the tag matches `SCRIPT_VERSION` in `install.sh`

**`.github/workflows/update-mirrors.yml`** — runs the first Monday of each month; diffs the Wikipedia mirror list against `mirrors.txt` and opens a PR if the set has changed

## Notes
- Mirror list is not maintained manually — CI keeps it current
- `--update-mirrors` extracts domains from `<li>archive.TLD</li>` elements in the Wikipedia infobox (precise; avoids false positives like `archive.org`)
- Comparison is set-based, so reordering alone does not trigger an update