### PR TITLE
ci: drop redundant shellcheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  shellcheck:
-    name: ShellCheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install ShellCheck
-        run: sudo apt-get install -y shellcheck
-
-      - name: Lint install.sh
-        run: shellcheck --severity=warning install.sh
-
   syntax:
     name: Bash Syntax
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ sudo ./install.sh --uninstall
 
 ## CI workflows
 
-- **ci.yml**: ShellCheck, bash syntax, mirrors.txt format validation, Linux dry-run (stubs out Darwin check)
+- **ci.yml**: bash syntax, mirrors.txt format validation, Linux dry-run (stubs out Darwin check). ShellCheck is **not** in CI — it runs locally via the global `shell-lint-fix` pre-commit hook (`~/.config/pre-commit/config.yaml`), so every authorized commit is already linted before push.
 - **release.yml**: Validates tag matches `SCRIPT_VERSION`, lints, publishes release
 - **update-mirrors.yml**: Monthly Wikipedia scrape, opens PR if mirror set changed
 


### PR DESCRIPTION
## Summary

- Delete the `shellcheck` job from `.github/workflows/ci.yml`. ShellCheck already runs locally via the global `shell-lint-fix` pre-commit hook (`~/.config/pre-commit/config.yaml`) on every authorized commit, and the local Phase 2 multi-step review covers any pushed change. CI duplication adds runner time without catching anything new.
- Keep the `syntax` job (validates `mirrors.txt` format and `bash -n install.sh` — repo-specific, not covered locally) and `dry-run` job (Linux-side install.sh exercise — needs CI environment).
- Keep `release.yml`'s pre-release shellcheck step as a belt-and-suspenders check before publishing tagged releases.
- Update `CLAUDE.md` "CI workflows" section so the description matches reality.

Same pattern as smartwatermelon/mac-server-setup#118 and smartwatermelon/mac-dev-server-setup#25.

## Test plan

- [x] `shellcheck -S info install.sh` — clean (verified via local pre-commit)
- [x] Local code-reviewer + adversarial-reviewer (elevated): PASS
- [x] Local Phase 2 codebase review: PASS
- [ ] CI Claude Blocking Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)