### PR TITLE
ci: harden update-mirrors workflow against upstream anomalies

### DIFF
--- a/.github/workflows/update-mirrors.yml
+++ b/.github/workflows/update-mirrors.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
+
+env:
+  ANOMALY_LABEL: mirror-source-anomaly
 
 jobs:
   update-mirrors:
@@ -27,12 +31,21 @@ jobs:
         run: |
           WIKIPEDIA_API="https://en.wikipedia.org/w/api.php?action=parse&page=Archive.today&prop=text&format=json"
 
-          echo "Fetching Wikipedia article..."
-          curl --silent --fail --max-time 30 --location "$WIKIPEDIA_API" -o /tmp/wiki.json
+          # Fetch and parse are wrapped in `if !` so a network or JSON-shape
+          # failure produces a structured anomaly rather than crashing the step.
+          ANOMALY_REASON=""
 
-          # Extract <li>archive.TLD</li> entries from the infobox HTML.
-          # Writing to a temp file avoids any shell-quoting issues with the JSON.
-          python3 - /tmp/wiki.json <<'PYEOF' > /tmp/new_domains.txt
+          echo "Fetching Wikipedia article..."
+          if ! curl --silent --fail --max-time 30 --location "$WIKIPEDIA_API" -o /tmp/wiki.json; then
+            ANOMALY_REASON="Failed to fetch Wikipedia API (network or HTTP error)."
+          fi
+
+          # Always create the output file so downstream `mapfile` is safe.
+          : > /tmp/new_domains.txt
+
+          if [[ -z "$ANOMALY_REASON" ]]; then
+            # Extract <li>archive.TLD</li> entries from the infobox HTML.
+            if ! python3 - /tmp/wiki.json > /tmp/new_domains.txt <<'PYEOF'
           import sys, json, re
 
           with open(sys.argv[1]) as f:
@@ -45,23 +58,86 @@ jobs:
                   seen.add(d)
                   print(d)
           PYEOF
-
-          if [[ ! -s /tmp/new_domains.txt ]]; then
-            echo "ERROR: No domains extracted from Wikipedia article" >&2
-            exit 1
+            then
+              ANOMALY_REASON="Failed to parse Wikipedia API response (unexpected JSON shape?)."
+            fi
           fi
 
-          # Ensure archive.today is first; preserve Wikipedia article ordering for the rest.
+          # Read current list and extracted set for sanity comparisons.
+          # Strip leading and trailing whitespace; the result feeds `grep -qx`,
+          # which would otherwise be sensitive to stray whitespace.
+          mapfile -t CURRENT < <(
+            grep -E '^[^#[:space:]]' mirrors.txt | awk '{$1=$1; print}'
+          )
+          mapfile -t EXTRACTED < /tmp/new_domains.txt
+
+          echo "Current mirrors.txt domains (${#CURRENT[@]}):"
+          if [[ ${#CURRENT[@]} -gt 0 ]]; then
+            printf '  %s\n' "${CURRENT[@]}"
+          fi
+          echo "Extracted from Wikipedia (${#EXTRACTED[@]}):"
+          if [[ ${#EXTRACTED[@]} -gt 0 ]]; then
+            printf '  %s\n' "${EXTRACTED[@]}"
+          else
+            echo "  (none)"
+          fi
+          echo
+
+          # Sanity checks (skipped if fetch/parse already failed above):
+          # 1) Non-empty result.
+          # 2) Result includes the primary domain (archive.today).
+          # 3) At most one currently-listed mirror is absent from the extraction.
+          # Operating principle: update if confident, never degrade.
+          if [[ -z "$ANOMALY_REASON" ]]; then
+            if [[ ${#EXTRACTED[@]} -eq 0 ]]; then
+              ANOMALY_REASON="Extraction returned zero domains (Wikipedia infobox parse yielded no matches)."
+            elif ! printf '%s\n' "${EXTRACTED[@]}" | grep -qx 'archive.today'; then
+              ANOMALY_REASON="Extraction is missing the primary domain (archive.today)."
+            else
+              MISSING_LIST=""
+              MISSING_COUNT=0
+              for d in "${CURRENT[@]}"; do
+                if ! printf '%s\n' "${EXTRACTED[@]}" | grep -qx "$d"; then
+                  MISSING_LIST="${MISSING_LIST:+${MISSING_LIST}, }${d}"
+                  MISSING_COUNT=$((MISSING_COUNT + 1))
+                fi
+              done
+              if [[ $MISSING_COUNT -gt 1 ]]; then
+                ANOMALY_REASON="Extraction is missing ${MISSING_COUNT} currently-listed mirrors"
+                ANOMALY_REASON+=" (${MISSING_LIST}); maximum allowed drop per run is 1."
+              fi
+            fi
+          fi
+
+          if [[ -n "$ANOMALY_REASON" ]]; then
+            echo "ANOMALY: $ANOMALY_REASON"
+            echo "mirrors.txt will not be modified."
+            echo "status=anomaly" >> "$GITHUB_OUTPUT"
+            {
+              echo "anomaly_reason<<EOF"
+              echo "$ANOMALY_REASON"
+              echo "EOF"
+              echo "extracted_summary<<EOF"
+              if [[ ${#EXTRACTED[@]} -eq 0 ]]; then
+                echo "(none)"
+              else
+                printf '%s\n' "${EXTRACTED[@]}"
+              fi
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Healthy. Ensure archive.today is first; preserve Wikipedia article ordering for the rest.
           {
             echo "archive.today"
             grep -v '^archive\.today$' /tmp/new_domains.txt
           } > /tmp/ordered_domains.txt
 
-          echo "Domains found on Wikipedia:"
-          cat /tmp/ordered_domains.txt
+          echo "status=healthy" >> "$GITHUB_OUTPUT"
 
           # Compare sorted sets (order differences don't constitute an update).
-          CURRENT_SORTED="$(grep -E '^[^#[:space:]]' mirrors.txt | sed 's/[[:space:]]*//' | sort)"
+          CURRENT_SORTED="$(printf '%s\n' "${CURRENT[@]}" | sort)"
           NEW_SORTED="$(sort /tmp/ordered_domains.txt)"
 
           if [[ "$CURRENT_SORTED" == "$NEW_SORTED" ]]; then
@@ -95,8 +171,105 @@ jobs:
             } > mirrors.txt
           fi
 
+      - name: Open or update anomaly issue
+        if: steps.check.outputs.status == 'anomaly' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ANOMALY_REASON: ${{ steps.check.outputs.anomaly_reason }}
+          EXTRACTED_SUMMARY: ${{ steps.check.outputs.extracted_summary }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Ensure the anomaly label exists (idempotent). --force re-asserts the
+          # workflow as the source of truth for the label's color and description.
+          gh label create "$ANOMALY_LABEL" \
+            --description "Wikipedia source returned anomalous data; mirrors.txt left untouched." \
+            --color BFD4F2 \
+            --force
+
+          EXISTING="$(gh issue list \
+            --state open \
+            --label "$ANOMALY_LABEL" \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          WIKI_URL="https://en.wikipedia.org/wiki/Archive.today"
+          SPEC_PATH="docs/superpowers/specs/2026-04-27-update-mirrors-resilience-design.md"
+          cat > /tmp/issue_body.md <<EOF
+          The monthly mirror-update workflow detected an anomaly in the Wikipedia source.
+          \`mirrors.txt\` was **not** modified.
+
+          **Failed sanity check:**
+
+          \`\`\`
+          ${ANOMALY_REASON}
+          \`\`\`
+
+          **Domains extracted from Wikipedia this run:**
+
+          \`\`\`
+          ${EXTRACTED_SUMMARY}
+          \`\`\`
+
+          **Workflow run:** ${RUN_URL}
+
+          **Operator checklist:**
+
+          - [ ] Inspect the [Archive.today Wikipedia article](${WIKI_URL}) —
+                has the infobox mirror list been removed or changed?
+          - [ ] Decide whether to update \`mirrors.txt\` manually.
+          - [ ] Consider alternative sources (see \`${SPEC_PATH}\`).
+
+          This issue auto-closes when the workflow next sees a healthy extraction.
+          EOF
+
+          if [[ -z "$EXISTING" ]]; then
+            gh issue create \
+              --title "Mirror update workflow: source anomaly detected" \
+              --label "$ANOMALY_LABEL" \
+              --body-file /tmp/issue_body.md
+          else
+            # Skip commenting if the most recent communication on the issue
+            # already records this same anomaly reason. Avoids unbounded
+            # comment noise when the upstream source stays broken for months.
+            LATEST_BODY="$(
+              gh issue view "$EXISTING" \
+                --json body,comments \
+                --jq '[.body] + (.comments | map(.body)) | last'
+            )"
+            if [[ "$LATEST_BODY" == *"$ANOMALY_REASON"* ]]; then
+              echo "Issue #${EXISTING} already records this anomaly — skipping comment."
+            else
+              echo "Existing anomaly issue #${EXISTING} found — appending comment."
+              gh issue comment "$EXISTING" --body-file /tmp/issue_body.md
+            fi
+          fi
+
+      - name: Close recovered anomaly issues
+        if: steps.check.outputs.status == 'healthy' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          OPEN_NUMS="$(gh issue list \
+            --state open \
+            --label "$ANOMALY_LABEL" \
+            --json number \
+            --jq '.[].number')"
+          if [[ -z "$OPEN_NUMS" ]]; then
+            exit 0
+          fi
+          while IFS= read -r n; do
+            [[ -z "$n" ]] && continue
+            echo "Closing recovered anomaly issue #${n}."
+            gh issue comment "$n" --body "Source recovered on run ${RUN_URL} — closing automatically."
+            gh issue close "$n"
+          done <<< "$OPEN_NUMS"
+
       - name: Create pull request
-        if: steps.check.outputs.up_to_date == 'false' && inputs.dry_run != 'true'
+        if: >-
+          steps.check.outputs.status == 'healthy' &&
+          steps.check.outputs.up_to_date == 'false' &&
+          inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -133,10 +306,18 @@ jobs:
       - name: Dry run summary
         if: inputs.dry_run == 'true'
         run: |
-          if [[ "${{ steps.check.outputs.up_to_date }}" == "true" ]]; then
-            echo "Dry run: mirrors.txt is already up to date."
-          else
-            echo "Dry run: changes detected. A PR would be created if dry_run=false."
-            echo "Updated mirror list:"
-            cat /tmp/ordered_domains.txt
-          fi
+          case "${{ steps.check.outputs.status }}" in
+            anomaly)
+              echo "Dry run: anomaly detected. Would open or comment on the '${ANOMALY_LABEL}' issue."
+              echo "Reason: ${{ steps.check.outputs.anomaly_reason }}"
+              ;;
+            healthy)
+              if [[ "${{ steps.check.outputs.up_to_date }}" == "true" ]]; then
+                echo "Dry run: mirrors.txt is already up to date."
+              else
+                echo "Dry run: changes detected. A PR would be created if dry_run=false."
+                echo "Updated mirror list:"
+                cat /tmp/ordered_domains.txt
+              fi
+              ;;
+          esac

--- a/.github/workflows/update-mirrors.yml
+++ b/.github/workflows/update-mirrors.yml
@@ -64,7 +64,7 @@ jobs:
           fi
 
           # Read current list and extracted set for sanity comparisons.
-          # Strip leading and trailing whitespace; the result feeds `grep -qx`,
+          # Strip leading and trailing whitespace; the result feeds `grep -Fxq`,
           # which would otherwise be sensitive to stray whitespace.
           mapfile -t CURRENT < <(
             grep -E '^[^#[:space:]]' mirrors.txt | awk '{$1=$1; print}'
@@ -91,13 +91,13 @@ jobs:
           if [[ -z "$ANOMALY_REASON" ]]; then
             if [[ ${#EXTRACTED[@]} -eq 0 ]]; then
               ANOMALY_REASON="Extraction returned zero domains (Wikipedia infobox parse yielded no matches)."
-            elif ! printf '%s\n' "${EXTRACTED[@]}" | grep -qx 'archive.today'; then
+            elif ! printf '%s\n' "${EXTRACTED[@]}" | grep -Fxq 'archive.today'; then
               ANOMALY_REASON="Extraction is missing the primary domain (archive.today)."
             else
               MISSING_LIST=""
               MISSING_COUNT=0
               for d in "${CURRENT[@]}"; do
-                if ! printf '%s\n' "${EXTRACTED[@]}" | grep -qx "$d"; then
+                if ! printf '%s\n' "${EXTRACTED[@]}" | grep -Fxq "$d"; then
                   MISSING_LIST="${MISSING_LIST:+${MISSING_LIST}, }${d}"
                   MISSING_COUNT=$((MISSING_COUNT + 1))
                 fi

--- a/docs/superpowers/specs/2026-04-27-update-mirrors-resilience-design.md
+++ b/docs/superpowers/specs/2026-04-27-update-mirrors-resilience-design.md
@@ -1,0 +1,228 @@
+# Update-mirrors Workflow Resilience
+
+**Date**: 2026-04-27
+**Status**: Approved, awaiting implementation
+**Scope**: `.github/workflows/update-mirrors.yml` only
+
+## Problem
+
+The monthly `update-mirrors.yml` workflow extracts mirror domains from the
+Wikipedia article *Archive.today* using the regex `<li>archive\.[a-z]{2,6}</li>`.
+That regex targets the article's infobox sidebar list of mirror TLDs. Edit wars
+on the article have removed the bare-domain list — the TLDs now appear only in
+prose (e.g. `.TODAY .FO .LI .VN .MD .PH`), so the regex returns zero matches.
+
+The current behaviour on zero matches is `exit 1`, which fails CI. The April
+2026 scheduled run was the first to hit this; prior runs were green.
+
+A subtler risk: if the regex were ever to start producing *partial* matches
+(e.g. only some mirrors in `<li>` form after a future article rewrite), the
+existing `[[ ! -s /tmp/new_domains.txt ]]` check would let a degraded list
+through and the workflow would propose a PR that drops legitimate entries from
+`mirrors.txt`.
+
+## Goal
+
+Operating principle (per stakeholder): **update if confident, never degrade.**
+
+- The workflow must not fail CI when the Wikipedia source is missing or
+  anomalous.
+- `mirrors.txt` must never be overwritten with an extraction that fails sanity
+  checks.
+- The operator must receive a visible signal (a GitHub issue) when the source
+  goes wrong, so this isn't a silent skip.
+- Idempotent across monthly runs: repeated anomalies must not spawn duplicate
+  issues.
+- Best-effort, low-maintenance: this is an open-source side project, not a
+  product.
+
+Out of scope: `install.sh --update-mirrors` (separate concern; user-invoked,
+already prints a clear error).
+
+## Design
+
+### Sanity checks
+
+After extracting domains from the Wikipedia API response, validate the result
+against three rules. **All three must pass** for the PR step to proceed.
+
+| # | Rule                                                               | Rationale                                                                   |
+|---|--------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| 1 | Result is non-empty                                                | Catches today's failure mode: parses fine but yields zero matches.          |
+| 2 | Result contains `archive.today`                                    | The primary domain is structural. If it's missing, our extraction is wrong. |
+| 3 | At most one domain currently in `mirrors.txt` is absent from the result | Mirrors have historically never been removed; any drop ≥ 2 is suspect.      |
+
+If any check fails, the workflow takes the **anomaly path** (below) instead of
+proposing a PR.
+
+### Anomaly path
+
+When sanity checks fail:
+
+1. Print to the workflow log: which check tripped, the raw extracted set, and
+   the count.
+2. Look up open issues with the label `mirror-source-anomaly`:
+   - **None open**: create one. Title `Mirror update workflow: source anomaly
+     detected`. Body lists the failing check, the extracted domains, a link to
+     the failing run, and a brief operator checklist (review the Wikipedia
+     article, consider manual `mirrors.txt` update, consider alternative
+     sources).
+   - **One open**: post a dated comment summarising this run's result. Don't
+     create a duplicate.
+3. Skip the PR-creation step entirely; `mirrors.txt` is never touched.
+4. Exit 0 — the GH Actions UI shows green; the *issue* is the signal.
+
+The `mirror-source-anomaly` label is created lazily by the workflow if
+missing (`gh label create --force`).
+
+### Recovery path
+
+On *every* healthy run (sanity checks pass):
+
+1. Look up open issues with label `mirror-source-anomaly`.
+2. For any found, post a comment ("source recovered on run #N"), then close.
+3. Continue with the existing diff/PR logic.
+
+When no anomaly issue is open this is a cheap no-op, so it's safe to run
+unconditionally on the healthy path. This keeps the issue list self-clearing.
+
+### Healthy path (unchanged)
+
+When sanity checks pass and the sorted set differs from current `mirrors.txt`,
+the existing PR-creation step runs as today. Title, body template, branch
+naming, and labelling are not modified.
+
+### Permissions
+
+Add `issues: write` to the workflow's `permissions:` block. Existing
+`contents: write` and `pull-requests: write` stay.
+
+## What's NOT changing
+
+- `install.sh --update-mirrors` — separate user-invoked path, fine as-is.
+- `mirrors.txt` format and contents.
+- The Python extraction regex — it's correct; the article is what changed.
+  Loosening the regex risks false positives from article prose and runs counter
+  to "never degrade."
+- Cron schedule, `workflow_dispatch` inputs, dry-run behaviour, PR
+  title/body when the healthy path runs.
+
+## Testing
+
+- **Local**: Pipe canned API JSON through the workflow's Python step (empty
+  result, missing primary, missing 2+ existing mirrors, healthy result).
+  Confirm each path produces the expected log output.
+- **Smoke (`workflow_dispatch` with `dry_run: true`)**: Trigger against the
+  current (broken) Wikipedia article. Should detect anomaly, print clearly,
+  and *not* mutate state (dry-run protects issue creation as well).
+- **Real**: After merge, the next scheduled run should open exactly one
+  `mirror-source-anomaly` issue, then subsequent runs should comment on it
+  rather than duplicate.
+
+## Research appendix — alternative mirror-list sources
+
+Documented for future reference, not implemented. Each candidate evaluated on:
+freshness (how quickly it reflects reality), authority (signal quality),
+false-positive risk, automation cost, infrastructure dependency.
+
+### 1. Certificate Transparency logs (crt.sh)
+
+Query crt.sh for certificates whose Subject Alternative Names include
+`archive.<TLD>`, parse SANs, deduplicate.
+
+- **Authority**: High when archive.today owns the cert directly. Reduced when
+  Cloudflare-fronted (shared cert farms include unrelated SANs).
+- **Freshness**: New certs appear within hours of issuance.
+- **False positives**: Significant — Cloudflare's shared cert farms historically
+  return long SAN lists. Requires filtering by issuer and SAN pattern.
+- **Automation cost**: Moderate — JSON API exists; SAN parsing and deduping
+  needed. Rate limits.
+- **Infra dependency**: External free service; occasionally slow.
+- **Verdict**: Best candidate for an authoritative cross-check, but the
+  filtering logic is non-trivial and Cloudflare adds noise.
+
+### 2. DNS probing of a bounded TLD space
+
+For each candidate TLD in a fixed list (`{today, fo, is, li, md, ph, vn, …}`)
+plus an enumeration of all 2–6 letter TLDs, resolve `archive.<TLD>` and
+fingerprint the response (HTTP 200 + expected page hash, or DNS pointing to
+archive.today's IP set).
+
+- **Authority**: High for "does this exist" questions; lower for "is this
+  endorsed by the project."
+- **Freshness**: Real-time.
+- **False positives**: Low if fingerprint is strict; high if you only check
+  that the name resolves (squatters exist).
+- **Automation cost**: Moderate. Bounded TLD enumeration is ~thousands of
+  lookups; doable but slow on each run.
+- **Infra dependency**: Public DNS, the archive itself.
+- **Verdict**: Useful as a *validator* (prune dead mirrors from the existing
+  list) but not a discoverer of unknowns unless paired with a TLD list.
+
+### 3. archive.today's own site
+
+Scrape archive.today's footer or about page for mirror references.
+
+- **Authority**: Highest.
+- **Freshness**: Whatever the site reflects.
+- **Automation cost**: Low to moderate.
+- **Infra dependency**: archive.today + Cloudflare. CI runners are likely
+  challenged by Cloudflare's bot mitigation, *and* the entire reason this
+  project exists is that archive.today is unreliable from default DNS.
+- **Verdict**: Authoritative but operationally fragile from a CI runner.
+
+### 4. Third-party filter lists / DNS allowlists
+
+Browser-extension blocklists (uBlock Origin), public DNS resolvers (NextDNS,
+Pi-hole community lists), and similar third-party catalogues sometimes
+enumerate archive.today mirrors.
+
+- **Authority**: Variable; depends on maintainer.
+- **Freshness**: Variable.
+- **False positives**: Possible; lists may include defunct or hostile mirrors.
+- **Automation cost**: Low — most are plain-text URLs.
+- **Infra dependency**: Each list's host.
+- **Verdict**: Useful as a low-effort cross-reference, not as a primary source.
+
+### 5. GitHub code search
+
+Search GitHub for repositories that maintain similar mirror lists (resolver
+scripts, browser extensions, archive helpers); aggregate their lists and look
+for mirror domains that appear in ≥ N independent projects.
+
+- **Authority**: Crowd-sourced.
+- **Freshness**: Variable.
+- **False positives**: Moderate.
+- **Automation cost**: Moderate. Requires query design and de-duplication.
+- **Infra dependency**: GitHub Search API rate limits.
+- **Verdict**: Interesting for cross-validation; brittle as a primary feed.
+
+### 6. Wayback Machine snapshots of Wikipedia
+
+Fetch a pre-edit-war snapshot of the Archive.today Wikipedia article from the
+Wayback Machine; run today's regex against it.
+
+- **Authority**: As good as Wikipedia was on the snapshot date.
+- **Freshness**: Frozen — only useful for backfill, not ongoing tracking.
+- **Verdict**: One-time recovery tool, not a long-term source.
+
+### 7. Manual curation (baseline)
+
+Maintain `mirrors.txt` by hand; treat the workflow purely as a watchdog that
+notifies on anomalies (which is essentially what this design produces when
+Wikipedia stays broken).
+
+- **Authority**: As good as the maintainer's diligence.
+- **Cost**: Lowest; no infrastructure.
+- **Verdict**: Likely the de-facto state for the foreseeable future. The
+  list has 7 entries and changes rarely.
+
+### Recommendation
+
+Keep Wikipedia as the primary source. The proposed resilience hardening is
+sufficient for now. If the `mirror-source-anomaly` issue persists across
+multiple monthly runs without recovery, revisit crt.sh as a secondary
+cross-check — it's the only candidate with both authoritative provenance and
+machine-friendly access. Until then, manual curation is fine: the cost of a
+yearly hand-edit is lower than the cost of maintaining multi-source consensus
+logic.


### PR DESCRIPTION
## Summary

The Archive.today Wikipedia article's infobox bare-domain list was edit-warred out, breaking the strict `<li>archive.TLD</li>` regex and failing the April 2026 scheduled run of `update-mirrors.yml`.

This PR hardens the workflow under the operating principle **update if confident, never degrade**.

- **Three sanity checks** gate the PR step:
  1. Extraction is non-empty.
  2. Extraction contains the primary domain (`archive.today`).
  3. At most one currently-listed mirror is absent from the extraction.
- **Resilient fetch/parse**: `curl` and `python3` are wrapped in `if !` so a network error or unexpected JSON shape produces a structured anomaly rather than crashing the step.
- **Anomaly path**: opens a labelled (`mirror-source-anomaly`) GitHub issue, deduplicating against the most-recent body/comment to avoid noise on long-running outages. `mirrors.txt` is left untouched. Workflow exits 0.
- **Recovery path**: every healthy run auto-closes any open `mirror-source-anomaly` issues.
- **Hardening**: `grep -Fxq` (literal match) closes the auto-filed issue #13 about the regex any-char footgun in `archive.today`. `mirrors.txt` lines are now whitespace-normalized via `awk` before feeding `grep -Fxq`.
- Adds `issues: write` permission and an `ANOMALY_LABEL` env var. The healthy PR-creation logic is unchanged.

`install.sh --update-mirrors` is intentionally out of scope (separate, user-invoked path).

Design and a research appendix on alternative mirror-list sources (CT logs, DNS probing, archive.today's own site, third-party filter lists, GitHub code search, Wayback Machine, manual curation) are in `docs/superpowers/specs/2026-04-27-update-mirrors-resilience-design.md`.

## Test plan

- [x] `yamllint` clean.
- [x] `bash -n` clean for all five run blocks.
- [x] Local smoke test: 8 simulated extractions (curl-fail, empty, missing-primary, drop-2, drop-1-allowed, identical, added-new, mirrors.txt-with-trailing-whitespace) all classified correctly.
- [ ] **After merge**: confirm the next scheduled run opens exactly one `mirror-source-anomaly` issue (since the article remains broken).
- [ ] **After merge**: confirm a subsequent run with the same anomaly comments only if the reason changed.
- [ ] **After merge**: confirm a manual `workflow_dispatch` with `dry_run: true` reports the anomaly without mutating issue or PR state.

Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)